### PR TITLE
Move the builder config entry point back to `builder.dart`

### DIFF
--- a/build_cli/CHANGELOG.md
+++ b/build_cli/CHANGELOG.md
@@ -1,12 +1,9 @@
-## 0.2.0
+## 0.1.1
 
 - Add setup instructions to `README.md`.
 - Use the logger built into `pkg:build`.
 - Don't generate CLI entries for unassignable fields.
 - Support latest `pkg:source_gen`. 
-- *BREAKING* (strictly speaking, but not likely.)
-  - Removed `package:build_cli/builder.dart`.
-  - Moved and renamed the builder factory to `build_cli.dart`.
 
 ## 0.1.0
 

--- a/build_cli/build.yaml
+++ b/build_cli/build.yaml
@@ -15,8 +15,8 @@ targets:
 builders:
   build_cli:
     target: noop
-    import: "package:build_cli/build_cli.dart"
-    builder_factories: ["createBuilderForCliGenerator"]
+    import: "package:build_cli/builder.dart"
+    builder_factories: ["cliBuilder"]
     build_extensions: {".dart": [".g.dart"]}
     auto_apply: dependents
     build_to: source

--- a/build_cli/build.yaml
+++ b/build_cli/build.yaml
@@ -16,7 +16,7 @@ builders:
   build_cli:
     target: noop
     import: "package:build_cli/builder.dart"
-    builder_factories: ["cliBuilder"]
+    builder_factories: ["buildCli"]
     build_extensions: {".dart": [".g.dart"]}
     auto_apply: dependents
     build_to: source

--- a/build_cli/lib/build_cli.dart
+++ b/build_cli/lib/build_cli.dart
@@ -7,39 +7,4 @@
 /// for more information.
 library build_cli;
 
-import 'package:build/build.dart';
-import 'package:logging/logging.dart';
-import 'package:source_gen/source_gen.dart';
-
-import 'src/build_cli_generator.dart';
-
 export 'src/build_cli_generator.dart' show CliGenerator;
-
-// TODO: until we can use `log` here - github.com/dart-lang/build/issues/1223
-final _logger = new Logger('build_cli');
-
-/// Supports `package:build_runner` creation and configuration of `build_cli`.
-///
-/// Not meant to be invoked by hand-authored code.
-Builder createBuilderForCliGenerator(BuilderOptions options) {
-  // Paranoid copy of options.config - don't assume it's mutable or needed
-  // elsewhere.
-  var optionsMap = new Map<String, dynamic>.from(options.config);
-
-  try {
-    return _cliPartBuilder(header: optionsMap.remove('header') as String);
-  } finally {
-    if (optionsMap.isNotEmpty) {
-      _logger.warning('These options were ignored: `$optionsMap`.');
-    }
-  }
-}
-
-Builder _cliPartBuilder({String header}) {
-  return new PartBuilder(
-    const [
-      const CliGenerator(),
-    ],
-    header: header,
-  );
-}

--- a/build_cli/lib/builder.dart
+++ b/build_cli/lib/builder.dart
@@ -1,0 +1,40 @@
+/// Configuration for using `package:build`-compatible build systems.
+///
+/// This library is **not** intended to be imported by typical end-users unless
+/// you are creating a custom compilation pipeline.
+///
+/// See [package:build_runner](https://pub.dartlang.org/packages/build_runner)
+/// for more information.
+library builder;
+
+import 'package:build/build.dart';
+import 'package:logging/logging.dart';
+import 'package:source_gen/source_gen.dart';
+
+import 'src/build_cli_generator.dart';
+
+// TODO: until we can use `log` here - github.com/dart-lang/build/issues/1223
+final _logger = new Logger('json_serializable');
+
+Builder cliBuilder(BuilderOptions options) {
+  // Paranoid copy of options.config - don't assume it's mutable or needed
+  // elsewhere.
+  var optionsMap = new Map<String, dynamic>.from(options.config);
+
+  try {
+    return _cliPartBuilder(header: optionsMap.remove('header') as String);
+  } finally {
+    if (optionsMap.isNotEmpty) {
+      _logger.warning('These options were ignored: `$optionsMap`.');
+    }
+  }
+}
+
+Builder _cliPartBuilder({String header}) {
+  return new PartBuilder(
+    const [
+      const CliGenerator(),
+    ],
+    header: header,
+  );
+}

--- a/build_cli/lib/builder.dart
+++ b/build_cli/lib/builder.dart
@@ -16,7 +16,7 @@ import 'src/build_cli_generator.dart';
 // TODO: until we can use `log` here - github.com/dart-lang/build/issues/1223
 final _logger = new Logger('json_serializable');
 
-Builder cliBuilder(BuilderOptions options) {
+Builder buildCli(BuilderOptions options) {
   // Paranoid copy of options.config - don't assume it's mutable or needed
   // elsewhere.
   var optionsMap = new Map<String, dynamic>.from(options.config);

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli
-version: 0.2.0-dev
+version: 0.1.1-dev
 description: >-
   Parse command line arguments directly into an annotation class
   using the power of build_runner and source_gen.


### PR DESCRIPTION
Per convention