### PR TITLE
Add nullable annotation for boolean field

### DIFF
--- a/build_cli/CHANGELOG.md
+++ b/build_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.2
+## 1.0.3
 
 - Support nullable annotation
 

--- a/build_cli/CHANGELOG.md
+++ b/build_cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.0.2
 
+- Support nullable annotation
+
+## 1.0.2
+
 - Support the latest release of `package:analyzer`.
 
 ## 1.0.1

--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -234,6 +234,7 @@ CliOption _getOptions(FieldElement element) {
       allowed: allowedValues,
       allowedHelp: allowedHelp,
       negatable: annotation.read('negatable').literalValue as bool,
+      nullable: (annotation.read('nullable')?.literalValue ?? false) as bool,
       hide: annotation.read('hide').literalValue as bool);
 
   var convertReader = annotation.read('convert');

--- a/build_cli/lib/src/build_cli_generator.dart
+++ b/build_cli/lib/src/build_cli_generator.dart
@@ -241,7 +241,9 @@ void _parserOptionFor(StringBuffer buffer, FieldElement element) {
     buffer.write(', valueHelp: ${escapeDartString(options.valueHelp)}');
   }
 
-  if (options.defaultsTo != null) {
+  if (info.argType == ArgType.flag && options.nullable) {
+    buffer.write(', defaultsTo: ${(options.defaultsTo as bool).toString()}');
+  } else if (options.defaultsTo != null) {
     var defaultValueLiteral = (info.argType == ArgType.flag)
         ? (options.defaultsTo as bool).toString()
         : escapeDartString(options.defaultsTo.toString());

--- a/build_cli/lib/src/build_cli_generator.dart
+++ b/build_cli/lib/src/build_cli_generator.dart
@@ -241,7 +241,7 @@ void _parserOptionFor(StringBuffer buffer, FieldElement element) {
     buffer.write(', valueHelp: ${escapeDartString(options.valueHelp)}');
   }
 
-  if (info.argType == ArgType.flag && options.nullable) {
+  if (info.argType == ArgType.flag && options.nullable == true) {
     buffer.write(', defaultsTo: ${(options.defaultsTo as bool).toString()}');
   } else if (options.defaultsTo != null) {
     var defaultValueLiteral = (info.argType == ArgType.flag)

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   build: '>=0.9.0 <2.0.0'
   # Limit version range on build_cli_annotations
   # new features need to stay in sync
-  build_cli_annotations: '>=0.1.2 <1.1.0'
+  build_cli_annotations: '>=1.0.1 <1.1.0'
   build_config: '>=0.2.6 <0.4.0'
   meta: ^1.1.0
   pub_semver: ^1.3.0

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -32,6 +32,7 @@ dev_dependencies:
   io: ^0.3.2
   path: ^1.5.1
   test: ^1.0.0
+
 dependency_overrides:
   build_cli_annotations: 
     path: ../build_cli_annotations

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -32,3 +32,6 @@ dev_dependencies:
   io: ^0.3.2
   path: ^1.5.1
   test: ^1.0.0
+dependency_overrides:
+  build_cli_annotations: 
+    path: ../build_cli_annotations

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli
-version: 1.0.3
+version: 1.0.3-dev
 description: >-
   Parse command line arguments directly into an annotation class
   using the power of build_runner and source_gen.

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli
-version: 1.0.2
+version: 1.0.3
 description: >-
   Parse command line arguments directly into an annotation class
   using the power of build_runner and source_gen.

--- a/build_cli/test/src/undefined_boolean_example.dart
+++ b/build_cli/test/src/undefined_boolean_example.dart
@@ -1,0 +1,14 @@
+import 'package:build_cli_annotations/build_cli_annotations.dart';
+
+part 'undefined_boolean_example.g.dart';
+
+@CliOptions()
+class NullableOptions {
+  @CliOption(
+    nullable: true,
+    defaultsTo: null,
+  )
+  final bool nullableOption;
+
+  NullableOptions(this.nullableOption);
+}

--- a/build_cli/test/src/undefined_boolean_example.g.dart
+++ b/build_cli/test/src/undefined_boolean_example.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'undefined_boolean_example.dart';
+
+// **************************************************************************
+// CliGenerator
+// **************************************************************************
+
+NullableOptions _$parseNullableOptionsResult(ArgResults result) =>
+    new NullableOptions(result['nullable-option'] as bool);
+
+ArgParser _$populateNullableOptionsParser(ArgParser parser) =>
+    parser..addFlag('nullable-option', defaultsTo: null);
+
+final _$parserForNullableOptions =
+    _$populateNullableOptionsParser(new ArgParser());
+
+NullableOptions parseNullableOptions(List<String> args) {
+  var result = _$parserForNullableOptions.parse(args);
+  return _$parseNullableOptionsResult(result);
+}

--- a/build_cli/test/undefined_boolean_example_integration_test.dart
+++ b/build_cli/test/undefined_boolean_example_integration_test.dart
@@ -1,0 +1,9 @@
+import 'package:test/test.dart';
+import 'src/undefined_boolean_example.dart';
+
+void main() {
+  test('should be null', () {
+    final options = parseNullableOptions([]);
+    expect(options.nullableOption, equals(null));
+  });
+}

--- a/build_cli_annotations/CHANGELOG.md
+++ b/build_cli_annotations/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Support nullable annotation
+
 ## 1.0.0
 
 - Update the version of `package:args` to `'>=1.5.0 <1.6.0'`.

--- a/build_cli_annotations/lib/build_cli_annotations.dart
+++ b/build_cli_annotations/lib/build_cli_annotations.dart
@@ -20,17 +20,17 @@ class CliOption {
   /// type.
   final dynamic Function(String) convert;
 
-  const CliOption(
-      {this.name,
-      this.abbr,
-      this.defaultsTo,
-      this.help,
-      this.valueHelp,
-      this.allowed,
-      this.negatable,
-      this.allowedHelp,
-      this.hide,
-      this.convert,
-      this.nullable,
-      });
+  const CliOption({
+    this.name,
+    this.abbr,
+    this.defaultsTo,
+    this.help,
+    this.valueHelp,
+    this.allowed,
+    this.negatable,
+    this.allowedHelp,
+    this.hide,
+    this.convert,
+    this.nullable,
+  });
 }

--- a/build_cli_annotations/lib/build_cli_annotations.dart
+++ b/build_cli_annotations/lib/build_cli_annotations.dart
@@ -14,6 +14,7 @@ class CliOption {
   final Map<Object, String> allowedHelp;
   final bool negatable;
   final bool hide;
+  final bool nullable;
 
   /// A top-level [Function] that converts an option value into the destination
   /// type.
@@ -29,5 +30,7 @@ class CliOption {
       this.negatable,
       this.allowedHelp,
       this.hide,
-      this.convert});
+      this.convert,
+      this.nullable,
+      });
 }

--- a/build_cli_annotations/pubspec.yaml
+++ b/build_cli_annotations/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli_annotations
-version: 1.0.1
+version: 1.0.1-dev
 description: >-
   Contains annotations for `package:build_cli`.
   See that package for more information.

--- a/build_cli_annotations/pubspec.yaml
+++ b/build_cli_annotations/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli_annotations
-version: 1.0.0
+version: 1.0.1
 description: >-
   Contains annotations for `package:build_cli`.
   See that package for more information.


### PR DESCRIPTION
Now, build_cli can't generate code which matched this:

```dart
// file.dart
import 'package:args/args.dart';

void main(Iterable<String> args) {
  final parser = new ArgParser()..addFlag('test', defaultsTo: null, negatable: true);
  final results = parser.parse(args);
  print(results['test']);
}
```

```dart
dart file.dart
// null
```
I am trying to fix this.