### PR TITLE
Compare underlying enum types using `getDisplayString`

### DIFF
--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -155,6 +155,7 @@ CliOption _getOptions(FieldElement element) {
             // An enum's values are non-nullable. For example, If the enum
             // field's type is `BuildTool?` it's accessors will be the
             // non-nullable type, `BuildTool`.
+            // TODO: find a better way to compare the underlying type
             p.returnType.getDisplayString(withNullability: false) ==
             element.type.getDisplayString(withNullability: false))
         .map((p) => p.name)
@@ -162,8 +163,12 @@ CliOption _getOptions(FieldElement element) {
 
     if (defaultsToReader != null && !defaultsToReader.isNull) {
       final objectValue = defaultsToReader.objectValue;
-      if (objectValue.type != element.type) {
-        throwUnsupported(element, 'this is also wack');
+      // TODO: find a better way to compare the underlying type
+      if (objectValue.type.getDisplayString(withNullability: false) !=
+          element.type.getDisplayString(withNullability: false)) {
+        throwUnsupported(
+            element,
+            'this is also wack');
       }
 
       defaultsTo =

--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -163,12 +163,12 @@ CliOption _getOptions(FieldElement element) {
 
     if (defaultsToReader != null && !defaultsToReader.isNull) {
       final objectValue = defaultsToReader.objectValue;
-      // TODO: find a better way to compare the underlying type
-      if (objectValue.type.getDisplayString(withNullability: false) !=
-          element.type.getDisplayString(withNullability: false)) {
+      if (objectValue.type != element.type) {
         throwUnsupported(
             element,
-            'this is also wack');
+            'The type provided to defaultsTo is '
+            'different than the field type. Check that the num types are the '
+            'same, or try making the field type non-nullable.');
       }
 
       defaultsTo =


### PR DESCRIPTION
I'm not sure if this is correct, so I added some TODOs. This is a problem if somehow the display strings are the same, e.g. if two symbols of the same name come from different libraries.

This fixes the case where an enum is nullable but has a defaultsTo value, where the default value is the non-nullable enum but the field is nullable.