### PR TITLE
latest mono repo

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,4 +1,4 @@
-# Created with package:mono_repo v5.0.4
+# Created with package:mono_repo v6.0.0
 name: Dart CI
 on:
   push:
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:stable"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:stable"
           restore-keys: |
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
       - id: checkout
         uses: actions/checkout@v2.4.0
       - name: mono_repo self validate
-        run: dart pub global activate mono_repo 5.0.4
+        run: dart pub global activate mono_repo 6.0.0
       - name: mono_repo self validate
         run: dart pub global run mono_repo generate --validate
   job_002:
@@ -41,13 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli-build_cli_annotations;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli-build_cli_annotations;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli-build_cli_annotations
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli-build_cli_annotations
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3
@@ -80,13 +80,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli-build_cli_annotations;commands:format"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli-build_cli_annotations;commands:format"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli-build_cli_annotations
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli-build_cli_annotations
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3
@@ -119,13 +119,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli-build_cli_annotations;commands:analyze"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli-build_cli_annotations;commands:analyze"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli-build_cli_annotations
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli-build_cli_annotations
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3
@@ -158,13 +158,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli-build_cli_annotations;commands:format"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli-build_cli_annotations;commands:format"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli-build_cli_annotations
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli-build_cli_annotations
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3
@@ -197,13 +197,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0;packages:build_cli
-            os:ubuntu-latest;pub-cache-hosted;dart:2.12.0
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0;packages:build_cli
+            os:ubuntu-latest;pub-cache-hosted;sdk:2.12.0
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3
@@ -231,13 +231,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache Pub hosted dependencies
-        uses: actions/cache@v2.1.6
+        uses: actions/cache@v2.1.7
         with:
           path: "~/.pub-cache/hosted"
-          key: "os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli;commands:test"
+          key: "os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli;commands:test"
           restore-keys: |
-            os:ubuntu-latest;pub-cache-hosted;dart:dev;packages:build_cli
-            os:ubuntu-latest;pub-cache-hosted;dart:dev
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev;packages:build_cli
+            os:ubuntu-latest;pub-cache-hosted;sdk:dev
             os:ubuntu-latest;pub-cache-hosted
             os:ubuntu-latest
       - uses: dart-lang/setup-dart@v1.3

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           sdk: stable
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - name: mono_repo self validate
         run: dart pub global activate mono_repo 5.0.4
       - name: mono_repo self validate
@@ -54,7 +54,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -93,7 +93,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -132,7 +132,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -171,7 +171,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -210,7 +210,7 @@ jobs:
         with:
           sdk: "2.12.0"
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"
@@ -244,7 +244,7 @@ jobs:
         with:
           sdk: dev
       - id: checkout
-        uses: actions/checkout@v2.3.5
+        uses: actions/checkout@v2.4.0
       - id: build_cli_pub_upgrade
         name: build_cli; dart pub upgrade
         if: "always() && steps.checkout.conclusion == 'success'"

--- a/build_cli/mono_pkg.yaml
+++ b/build_cli/mono_pkg.yaml
@@ -1,5 +1,5 @@
 # See with https://github.com/google/mono_repo.dart for details on this file
-dart:
+sdk:
 - 2.12.0
 - dev
 

--- a/build_cli_annotations/mono_pkg.yaml
+++ b/build_cli_annotations/mono_pkg.yaml
@@ -1,5 +1,5 @@
 # See with https://github.com/google/mono_repo.dart for details on this file
-dart:
+sdk:
 - 2.12.0
 - dev
 

--- a/tool/ci.sh
+++ b/tool/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Created with package:mono_repo v5.0.4
+# Created with package:mono_repo v6.0.0
 
 # Support built in commands on windows out of the box.
 # When it is a flutter repo (check the pubspec.yaml for "sdk: flutter")


### PR DESCRIPTION
- Bump actions/checkout from 2.3.5 to 2.4.0
- Bump actions/cache from 2.1.6 to 2.1.7
