### PR TITLE
🧹 Add validation for allowedHelp values

### DIFF
--- a/build_cli/CHANGELOG.md
+++ b/build_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.11-wip
+
+- Validate that `allowedHelp` keys match `allowed` values.
+
 ## 2.2.10
 
 - Support the latest `package:analyzer`.

--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -273,6 +273,19 @@ CliOption? _getOptions(FieldElement element) {
     );
   }
 
+  if (allowedHelp != null) {
+    final unallowedKeys = allowedHelp.keys
+        .where((k) => !(allowedValues?.contains(k) ?? false))
+        .toList();
+    if (unallowedKeys.isNotEmpty) {
+      throwUnsupported(
+        element,
+        'The `allowedHelp` keys – {${unallowedKeys.join(', ')}} '
+        'are not in `allowedValues`.',
+      );
+    }
+  }
+
   final option = CliOption(
     abbr: annotation.read('abbr').literalValue as String?,
     allowed: allowedValues,

--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -275,7 +275,8 @@ CliOption? _getOptions(FieldElement element) {
 
   if (allowedHelp != null) {
     final unallowedKeys = allowedHelp.keys
-        .where((k) => !(allowedValues?.contains(k) ?? false));
+        .where((k) => !(allowedValues?.contains(k) ?? false))
+        .toList();
     if (unallowedKeys.isNotEmpty) {
       throwUnsupported(
         element,

--- a/build_cli/lib/src/arg_info.dart
+++ b/build_cli/lib/src/arg_info.dart
@@ -275,8 +275,7 @@ CliOption? _getOptions(FieldElement element) {
 
   if (allowedHelp != null) {
     final unallowedKeys = allowedHelp.keys
-        .where((k) => !(allowedValues?.contains(k) ?? false))
-        .toList();
+        .where((k) => !(allowedValues?.contains(k) ?? false));
     if (unallowedKeys.isNotEmpty) {
       throwUnsupported(
         element,

--- a/build_cli/lib/src/build_cli_generator.dart
+++ b/build_cli/lib/src/build_cli_generator.dart
@@ -381,7 +381,6 @@ void _parserOptionFor(StringBuffer buffer, FieldElement element) {
   }
 
   if (options.allowedHelp != null) {
-    // TODO: throw/warn if `allowed` is null or doesn't match these?
     final allowedHelpItems = options.allowedHelp!.entries
         .map((e) {
           final escapedKey = escapeDartString(e.key.toString());

--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -1,5 +1,5 @@
 name: build_cli
-version: 2.2.10
+version: 2.2.11-wip
 description: >-
   Parse command line arguments directly into an annotation class
   using the power of build_runner and source_gen.

--- a/build_cli/test/build_cli_test.dart
+++ b/build_cli/test/build_cli_test.dart
@@ -44,6 +44,8 @@ Future<void> main() async {
         'UnsupportedFieldType',
         'WithCommand',
         'NonNullableTypes',
+        'AllowedHelpKeyNotInAllowed',
+        'AllowedHelpKeyNoAllowed',
       ],
     );
   });

--- a/build_cli/test/test_input/test_input.dart
+++ b/build_cli/test/test_input/test_input.dart
@@ -119,6 +119,26 @@ class FlagWithValueHelp {
   bool? option;
 }
 
+@ShouldThrow(
+  'Could not handle field `option`. '
+  'The `allowedHelp` keys – {c} are not in `allowedValues`.',
+)
+@CliOptions()
+class AllowedHelpKeyNotInAllowed {
+  @CliOption(allowed: ['a', 'b'], allowedHelp: {'a': 'a help', 'c': 'c help'})
+  String? option;
+}
+
+@ShouldThrow(
+  'Could not handle field `option`. '
+  'The `allowedHelp` keys – {a} are not in `allowedValues`.',
+)
+@CliOptions()
+class AllowedHelpKeyNoAllowed {
+  @CliOption(allowedHelp: {'a': 'a help'})
+  String? option;
+}
+
 @ShouldGenerate(
   r'''
 Empty _$parseEmptyResult(ArgResults result) => Empty();


### PR DESCRIPTION
🎯 **What:** Added validation to ensure `allowedHelp` keys are a subset of `allowed` values.
💡 **Why:** To improve maintainability and prevent misconfigurations by providing clear error messages when `allowedHelp` keys don't match `allowed` values.
✅ **Verification:** Added reproduction test cases to `test_input.dart` and verified the fix.
✨ **Result:** Improved error reporting and code cleanliness by removing an old TODO.

---
*PR created automatically by Jules for task [14463417469052939049](https://jules.google.com/task/14463417469052939049) started by @kevmoo*