### PR TITLE
⚡ optimize unused fields removal in generator

### DIFF
--- a/build_cli/lib/src/build_cli_generator.dart
+++ b/build_cli/lib/src/build_cli_generator.dart
@@ -101,13 +101,12 @@ ${element.name} $resultParserName(ArgResults result) =>''');
       deserializeForField,
     );
 
-    final unusedFields = fields.keys.toSet()..removeAll(usedFields);
-
-    if (unusedFields.isNotEmpty) {
+    if (fields.length > usedFields.length) {
+      final unusedFields = fields.keys.where((k) => !usedFields.contains(k));
       final fieldsString = unusedFields.map((f) => '`$f`').join(', ');
       log.warning('Skipping unassignable fields on `$element`: $fieldsString');
 
-      unusedFields.forEach(fields.remove);
+      fields.removeWhere((k, v) => !usedFields.contains(k));
     }
     yield buffer.toString();
 


### PR DESCRIPTION
💡 **What:** The optimization replaces the creation of an intermediate `Set` and a manual `forEach` removal loop with a lazy `where` iterable for logging and the built-in `removeWhere` method for modification. It also adds a fast `length` check guard.

🎯 **Why:** The previous implementation was suboptimal, allocating a new `Set` and performing multiple lookups to remove items. The new approach is more direct, avoids unnecessary allocations, and uses a constant-time check to skip the work when no fields need to be removed.

📊 **Measured Improvement:** While environmental limitations (timeouts) prevented running a full benchmark suite, this change is a clear algorithmic improvement. It reduces memory pressure by avoiding the allocation of a `Set<String>` of all field names and avoids the overhead of multiple `remove` calls and set subtractions. In cases with many fields and few unused ones, the `length` check provides an immediate O(1) skip.

---
*PR created automatically by Jules for task [730848308354357642](https://jules.google.com/task/730848308354357642) started by @kevmoo*