### PR TITLE
test: migrate test suite to package:checks

### DIFF
--- a/build_cli/pubspec.yaml
+++ b/build_cli/pubspec.yaml
@@ -28,6 +28,7 @@ dev_dependencies:
   args: ^2.6.0
   build_runner: ^2.10.5
   build_verify: ^3.0.0
+  checks: ^0.3.1
   dart_flutter_team_lints: ^3.2.0
   io: ^1.0.0
   path: ^1.9.0

--- a/build_cli/test/build_cli_test.dart
+++ b/build_cli/test/build_cli_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 
 import 'package:build_cli/build_cli.dart';
 import 'package:source_gen_test/source_gen_test.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 Future<void> main() async {
   const generator = CliGenerator();

--- a/build_cli/test/command_runner_integration_test.dart
+++ b/build_cli/test/command_runner_integration_test.dart
@@ -1,5 +1,6 @@
 import 'package:args/command_runner.dart';
-import 'package:test/test.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
 
 import 'src/command_runner_example.dart';
 
@@ -8,6 +9,8 @@ void main() {
     final runner = CommandRunner<void>('my_app', '')
       ..addCommand(CommitCommand());
     await runner.run(['commit', '--all']);
-    expect(CommitCommand.debugOptionsWhenRun?.all, isTrue);
+    check(
+      CommitCommand.debugOptionsWhenRun,
+    ).isNotNull().has((o) => o.all, 'all').isTrue();
   });
 }

--- a/build_cli/test/ensure_build_test.dart
+++ b/build_cli/test/ensure_build_test.dart
@@ -3,7 +3,7 @@
 library;
 
 import 'package:build_verify/build_verify.dart';
-import 'package:test/test.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test(

--- a/build_cli/test/nullable_defaults_example_integration_test.dart
+++ b/build_cli/test/nullable_defaults_example_integration_test.dart
@@ -1,13 +1,14 @@
-import 'package:test/test.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
 import 'src/nullable_defaults_example.dart';
 
 void main() {
   test('should be null', () {
     final options = parseNullableOptions([]);
-    expect(options.nullableBoolean, equals(null));
-    expect(options.nullableInteger, equals(null));
-    expect(options.nullableDouble, equals(null));
-    expect(options.nullableNum, equals(null));
+    check(options.nullableBoolean).isNull();
+    check(options.nullableInteger).isNull();
+    check(options.nullableDouble).isNull();
+    check(options.nullableNum).isNull();
   });
 
   test('should be value from arguments', () {
@@ -21,9 +22,9 @@ void main() {
       '--nullable-num',
       '3.4',
     ]);
-    expect(options.nullableBoolean, equals(true));
-    expect(options.nullableInteger, equals(10));
-    expect(options.nullableDouble, equals(1.1));
-    expect(options.nullableNum, equals(3.4));
+    check(options.nullableBoolean).equals(true);
+    check(options.nullableInteger).equals(10);
+    check(options.nullableDouble).equals(1.1);
+    check(options.nullableNum).equals(3.4);
   });
 }

--- a/build_cli/test/peanut_integration_test.dart
+++ b/build_cli/test/peanut_integration_test.dart
@@ -1,4 +1,5 @@
-import 'package:test/test.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
 
 import 'src/peanut_example.dart';
 
@@ -6,19 +7,19 @@ void main() {
   test('no args', () {
     final options = parsePeanutOptions([]);
 
-    expect(options.directory, 'web');
-    expect(options.branch, 'gh-pages');
-    expect(options.mode, PubBuildMode.release);
-    expect(options.modeWasParsed, isFalse);
-    expect(options.buildConfig, isNull);
-    expect(options.buildConfigWasParsed, isFalse);
-    expect(options.message, 'Built <directory>');
-    expect(options.buildTool, isNull);
-    expect(options.debugBuildTool, BuildTool.$loco);
-    expect(options.help, isFalse);
-    expect(options.release, isTrue);
-    expect(options.maxRuntime, isNull);
-    expect(options.rest, isEmpty);
+    check(options.directory).equals('web');
+    check(options.branch).equals('gh-pages');
+    check(options.mode).equals(PubBuildMode.release);
+    check(options.modeWasParsed).isFalse();
+    check(options.buildConfig).isNull();
+    check(options.buildConfigWasParsed).isFalse();
+    check(options.message).equals('Built <directory>');
+    check(options.buildTool).isNull();
+    check(options.debugBuildTool).equals(BuildTool.$loco);
+    check(options.help).isFalse();
+    check(options.release).isTrue();
+    check(options.maxRuntime).isNull();
+    check(options.rest).isEmpty();
   });
 
   test('some args', () {
@@ -39,20 +40,20 @@ void main() {
       'things',
     ]);
 
-    expect(options.directory, 'dir');
-    expect(options.branch, 'gh-pages');
-    expect(options.mode, PubBuildMode.debug);
-    expect(options.modeWasParsed, isTrue);
-    expect(options.buildConfig, isNull);
-    expect(options.buildConfigWasParsed, isFalse);
-    expect(options.bazelOptions, BazelOptions.toSource);
-    expect(options.message, 'Built <directory>');
-    expect(options.buildTool, isNull);
-    expect(options.debugBuildTool, BuildTool.pub);
-    expect(options.help, isTrue);
-    expect(options.release, isFalse);
-    expect(options.maxRuntime, const Duration(seconds: 42));
-    expect(options.rest, ['extra', 'things']);
+    check(options.directory).equals('dir');
+    check(options.branch).equals('gh-pages');
+    check(options.mode).equals(PubBuildMode.debug);
+    check(options.modeWasParsed).isTrue();
+    check(options.buildConfig).isNull();
+    check(options.buildConfigWasParsed).isFalse();
+    check(options.bazelOptions).equals(BazelOptions.toSource);
+    check(options.message).equals('Built <directory>');
+    check(options.buildTool).isNull();
+    check(options.debugBuildTool).equals(BuildTool.pub);
+    check(options.help).isTrue();
+    check(options.release).isFalse();
+    check(options.maxRuntime).equals(const Duration(seconds: 42));
+    check(options.rest).deepEquals(['extra', 'things']);
   });
 
   group('with invalid args', () {
@@ -67,12 +68,10 @@ void main() {
 
     for (var item in items.entries) {
       test('`${item.value.join(' ')}`', () {
-        expect(
-          () => parsePeanutOptions(item.value),
-          throwsA(
-            isFormatException.having((e) => e.message, 'message', item.key),
-          ),
-        );
+        check(() => parsePeanutOptions(item.value))
+            .throws<FormatException>()
+            .has((e) => e.message, 'message')
+            .equals(item.key);
       });
     }
   });
@@ -80,7 +79,7 @@ void main() {
   test('usage', () {
     final prettyUsage = prettyParser.usage;
     printOnFailure(prettyUsage);
-    expect(prettyUsage, r'''
+    check(prettyUsage).equals(r'''
 -d, --directory           (defaults to "web")
 -b, --branch              (defaults to "gh-pages")
     --mode                The mode to run `pub build` in.

--- a/build_cli/test/pubviz_integration_test.dart
+++ b/build_cli/test/pubviz_integration_test.dart
@@ -1,4 +1,5 @@
-import 'package:test/test.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
 
 import 'src/pubviz_example.dart';
 
@@ -6,12 +7,12 @@ void main() {
   test('no args', () {
     final options = parsePubvizOptions([]);
 
-    expect(options.secret, isNull);
-    expect(options.ignorePackages, <void>[]);
-    expect(options.productionPort, 8080);
-    expect(options.numValue, 3.14);
-    expect(options.doubleValue, 3000.0);
-    expect(options.devPort, 8080);
+    check(options.secret).isNull();
+    check(options.ignorePackages).isNotNull().isEmpty();
+    check(options.productionPort).equals(8080);
+    check(options.numValue).equals(3.14);
+    check(options.doubleValue).equals(3000);
+    check(options.devPort).equals(8080);
   });
 
   group('with invalid args', () {
@@ -41,12 +42,10 @@ void main() {
 
     for (var item in items.entries) {
       test('`${item.value.join(' ')}`', () {
-        expect(
-          () => parsePubvizOptions(item.value),
-          throwsA(
-            isFormatException.having((e) => e.message, 'message', item.key),
-          ),
-        );
+        check(() => parsePubvizOptions(item.value))
+            .throws<FormatException>()
+            .has((e) => e.message, 'message')
+            .equals(item.key);
       });
     }
   });
@@ -54,7 +53,7 @@ void main() {
   test('usage', () {
     final prettyUsage = prettyParser.usage;
     printOnFailure(prettyUsage);
-    expect(prettyUsage, r'''
+    check(prettyUsage).equals(r'''
 -f, --format                    
           [dot]                 Generate a GraphViz 'dot' file.
           [html] (default)      Wrap the GraphViz dot format in an HTML template

--- a/build_cli/test/readme_test.dart
+++ b/build_cli/test/readme_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
-import 'package:test/test.dart';
+import 'package:checks/checks.dart';
+import 'package:test/scaffolding.dart';
 
 void main() {
   test('readme contents', () {
@@ -18,6 +19,6 @@ void main() {
 
     printOnFailure(exampleContent);
 
-    expect(readmeContent, contains(exampleContent));
+    check(readmeContent).contains(exampleContent);
   });
 }


### PR DESCRIPTION
Migrates the test suite from `package:matcher` to `package:checks`.

Verified 100% clean static analysis (`dart analyze`) and all tests passing (`dart test`).