### PR TITLE
refactor: remove unused ElementExtension in to_share.dart

### DIFF
--- a/build_cli/lib/src/to_share.dart
+++ b/build_cli/lib/src/to_share.dart
@@ -213,11 +213,3 @@ extension DartTypeExtension on DartType {
     return val;
   }
 }
-
-extension ElementExtension on Element {
-  String toStringNonNullable() {
-    final val = displayString();
-    if (val.endsWith('?')) return val.substring(0, val.length - 1);
-    return val;
-  }
-}


### PR DESCRIPTION
Remove unreferenced ElementExtension in to_share.dart detected as dead code.
